### PR TITLE
Add drill based healthchecks to unbound and stubby.

### DIFF
--- a/stubby/Dockerfile
+++ b/stubby/Dockerfile
@@ -48,7 +48,7 @@ RUN set -e -x && \
       $build_deps \
       ca-certificates \
       dns-root-data \
-      dnsutils \
+      ldnsutils \
       libev4 \
       libevent-core-2.0.5 \
       libidn11 \
@@ -81,6 +81,6 @@ USER stubby:stubby
 
 COPY stubby.yml /opt/stubby/etc/stubby/stubby.yml
 
-HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD dig @127.0.0.1 -p 8053 cloudflare.com || exit 1
+HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD drill @127.0.0.1 -p 8053 cloudflare.com || exit 1
 
 CMD ["/opt/stubby/bin/stubby"]

--- a/stubby/Dockerfile
+++ b/stubby/Dockerfile
@@ -48,6 +48,7 @@ RUN set -e -x && \
       $build_deps \
       ca-certificates \
       dns-root-data \
+      dnsutils \
       libev4 \
       libevent-core-2.0.5 \
       libidn11 \
@@ -79,5 +80,7 @@ ENV PATH /opt/stubby/bin:$PATH
 USER stubby:stubby
 
 COPY stubby.yml /opt/stubby/etc/stubby/stubby.yml
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD dig @127.0.0.1 -p 8053 cloudflare.com || exit 1
 
 CMD ["/opt/stubby/bin/stubby"]

--- a/unbound/Dockerfile
+++ b/unbound/Dockerfile
@@ -63,6 +63,7 @@ RUN build_deps="ca-certificates curl gcc libc-dev libevent-dev libexpat1-dev mak
     debian_frontend=noninteractive apt-get update && apt-get install -y --no-install-recommends \
       $build_deps \
       bsdmainutils \
+      dnsutils \
       ldnsutils \
       libevent-2.0 \
       libexpat1 && \
@@ -99,5 +100,7 @@ RUN chmod +x /unbound.sh
 WORKDIR /opt/unbound/
 
 ENV PATH /opt/unbound/sbin:$PATH
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD dig @127.0.0.1 cloudflare.com || exit 1
 
 CMD ["/unbound.sh"]

--- a/unbound/Dockerfile
+++ b/unbound/Dockerfile
@@ -63,7 +63,6 @@ RUN build_deps="ca-certificates curl gcc libc-dev libevent-dev libexpat1-dev mak
     debian_frontend=noninteractive apt-get update && apt-get install -y --no-install-recommends \
       $build_deps \
       bsdmainutils \
-      dnsutils \
       ldnsutils \
       libevent-2.0 \
       libexpat1 && \
@@ -101,6 +100,6 @@ WORKDIR /opt/unbound/
 
 ENV PATH /opt/unbound/sbin:$PATH
 
-HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD dig @127.0.0.1 cloudflare.com || exit 1
+HEALTHCHECK --interval=5s --timeout=3s --start-period=5s CMD drill @127.0.0.1 cloudflare.com || exit 1
 
 CMD ["/unbound.sh"]


### PR DESCRIPTION
This is more of a proof of concept, but I was curious on your thoughts about adding healthchecks to the unbound and stubby containers.

I was inspired by the healthchecks in the pihole and cloudflared images.

https://github.com/pi-hole/docker-pi-hole/blob/23e65017c101266cfc1aa67339cd2fbebaf61d2e/Dockerfile_amd64#L42

https://github.com/visibilityspots/dockerfile-cloudflared/blob/27c069134f7cc830773c2f5fc526d06b117705c8/Dockerfile#L26

The healthchecks have saved me a few times from bad containers and it might be nice to have unbound and stubby similarly instrumented.