### PR TITLE
Removed 128-bit integer compilation flag

### DIFF
--- a/stubby/Dockerfile
+++ b/stubby/Dockerfile
@@ -22,7 +22,7 @@ RUN set -e -x && \
     gpg --batch --verify openssl.tar.gz.asc openssl.tar.gz && \
     tar xzf openssl.tar.gz && \
     cd "$version_openssl" && \
-    ./config --prefix=/opt/openssl no-weak-ssl-ciphers no-ssl3 no-shared enable-ec_nistp_64_gcc_128 -DOPENSSL_NO_HEARTBEATS -fstack-protector-strong && \
+    ./config --prefix=/opt/openssl no-weak-ssl-ciphers no-ssl3 no-shared -DOPENSSL_NO_HEARTBEATS -fstack-protector-strong && \
     make depend && \
     make && \
     make install_sw && \

--- a/unbound/Dockerfile
+++ b/unbound/Dockerfile
@@ -22,7 +22,7 @@ RUN set -e -x && \
     gpg --batch --verify openssl.tar.gz.asc openssl.tar.gz && \
     tar xzf openssl.tar.gz && \
     cd "$version_openssl" && \
-    ./config --prefix=/opt/openssl no-weak-ssl-ciphers no-ssl3 no-shared enable-ec_nistp_64_gcc_128 -DOPENSSL_NO_HEARTBEATS -fstack-protector-strong && \
+    ./config --prefix=/opt/openssl no-weak-ssl-ciphers no-ssl3 no-shared -DOPENSSL_NO_HEARTBEATS -fstack-protector-strong && \
     make depend && \
     make && \
     make install_sw && \


### PR DESCRIPTION
While trying to run this on a fresh Raspberry Pi, I kept running into an error during the `./config` section of the `docker build` process - I don't have the exact message on me anymore, but it was to the effect of "128-bit integers are not supported on this configuration". After googling around, it seems that ARM gcc simply [does not support 128-bit integers](https://stackoverflow.com/questions/16088282/is-there-a-128-bit-integer-in-gcc).

After removing the `enable-ec_nistp_64_gcc_128` flag from both builds, it all worked great. The OpenSSL site seems to indicate that this flag is mostly [for performance gains](https://wiki.openssl.org/index.php/Compilation_and_Installation) where available, and that it doesn't have a good way to detect if the flag should be used or not.

I'm not sure that removing it wholesale is the right move, but it worked for me, and seems to have no ill effect (on a Pi, at least).