### PR TITLE
Fix ping error message by installing ping

### DIFF
--- a/unbound/Dockerfile
+++ b/unbound/Dockerfile
@@ -107,6 +107,7 @@ RUN set -x && \
     DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
       bsdmainutils \
       ca-certificates \
+      iputils-ping \
       ldnsutils \
       libevent-2.1-7 \
       libnghttp2-14 \


### PR DESCRIPTION
I received the following error when creating the docker container, and it seems ping was not included in the install. This pr adds ping. 

`/unbound.sh: line 35: ping: command not found`